### PR TITLE
Change dir to the staging dir before doing a git init

### DIFF
--- a/lib/github_pages_rake_tasks/publish_task.rb
+++ b/lib/github_pages_rake_tasks/publish_task.rb
@@ -128,8 +128,10 @@ module GithubPagesRakeTasks
     def initialize_staging_repo
       interface.mkdir_p(staging_dir) unless interface.dir_exist?(staging_dir)
 
-      interface.sh('git init')
-      interface.sh("git remote add '#{remote_name}' '#{repo_url}'")
+      interface.chdir staging_dir do
+        interface.sh('git init')
+        interface.sh("git remote add '#{remote_name}' '#{repo_url}'")
+      end
     end
 
     # Creates `staging_dir` (if needed), clones the remote repository to it, and checks

--- a/lib/github_pages_rake_tasks/publish_task.rb
+++ b/lib/github_pages_rake_tasks/publish_task.rb
@@ -125,13 +125,16 @@ module GithubPagesRakeTasks
       end
     end
 
-    def initialize_staging_repo
-      interface.mkdir_p(staging_dir) unless interface.dir_exist?(staging_dir)
-
+    def initialize_git
       interface.chdir staging_dir do
         interface.sh('git init')
         interface.sh("git remote add '#{remote_name}' '#{repo_url}'")
       end
+    end
+
+    def initialize_staging_repo
+      interface.mkdir_p(staging_dir) unless interface.dir_exist?(staging_dir)
+      initialize_git
     end
 
     # Creates `staging_dir` (if needed), clones the remote repository to it, and checks

--- a/lib/github_pages_rake_tasks/version.rb
+++ b/lib/github_pages_rake_tasks/version.rb
@@ -3,5 +3,5 @@
 
 module GithubPagesRakeTasks
   # Version of this module
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/spec/lib/github_pages_rake_tasks/publish_task_spec.rb
+++ b/spec/lib/github_pages_rake_tasks/publish_task_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe GithubPagesRakeTasks::PublishTask do
             .once
         )
         expect(mocked_interface).to(
+          receive(:chdir)
+            .with(staging_dir) do |&block|
+            block.call(staging_dir)
+          end
+            .ordered
+            .once
+        )
+        expect(mocked_interface).to(
           receive(:sh)
             .with('git init')
             .ordered
@@ -233,6 +241,14 @@ RSpec.describe GithubPagesRakeTasks::PublishTask do
           receive(:dir_exist?)
             .with(staging_dir)
             .and_return(true)
+            .ordered
+            .once
+        )
+        expect(mocked_interface).to(
+          receive(:chdir)
+            .with(staging_dir) do |&block|
+            block.call(staging_dir)
+          end
             .ordered
             .once
         )


### PR DESCRIPTION
Correct a bug where git init was being done from where rake was run instead of the staging_dir