### PR TITLE
chdir to the staging directory when needed

### DIFF
--- a/lib/github_pages_rake_tasks/interface.rb
+++ b/lib/github_pages_rake_tasks/interface.rb
@@ -35,7 +35,7 @@ module GithubPagesRakeTasks
   class Interface
     extend Forwardable
 
-    def_delegators :@file_utils, :chdir, :rm_rf, :cp_r, :sh, :verbose
+    def_delegators :@file_utils, :chdir, :cp_r, :mkdir_p, :rm_rf, :sh, :verbose
     def_delegators :@dir, :mktmpdir
     def_delegator  :@dir, :exist?, :dir_exist?
     def_delegators :@file, :expand_path

--- a/lib/github_pages_rake_tasks/version.rb
+++ b/lib/github_pages_rake_tasks/version.rb
@@ -3,5 +3,5 @@
 
 module GithubPagesRakeTasks
   # Version of this module
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
Several commands needed to be run from within the staging_dir and were not (like git init).  These changes ensure that the appropriate commands are run from the staging_dir.