### PR TITLE
Make sure that predeply only runs once 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,15 @@ cache: bundler
 before_install: gem install bundler -v 2.0.1
 
 before_deploy:
-  - echo "machine github.com\n    login jcouball\n    password ${GITHUB_TOKEN}" > ~/.netrc
-  - git config --global user.email "travis@travis-ci.org"
-  - git config --global user.name "Travis CI"
-  - gem install bump
-  - bump patch --commit-message "[skip ci]"
+  - >
+    if ! [ "$HAS_ALREADY_RUN" ]; then
+      export HAS_ALREADY_RUN=1
+      echo "machine github.com\n    login jcouball\n    password ${GITHUB_TOKEN}" > ~/.netrc
+      git config --global user.email "travis@travis-ci.org"
+      git config --global user.name "Travis CI"
+      gem install bump
+      bump patch --commit-message "[skip ci]"
+    fi
 
 deploy:
   - provider: pages


### PR DESCRIPTION
The predeploy phase is used to bump the gem version.  However, predeploy is run once per deployment provider.  We only want to bump the gem version once.
