### PR TITLE
Ensure Travis build is not in a detached head state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_deploy:
       echo "machine github.com\n    login jcouball\n    password ${GITHUB_TOKEN}" > ~/.netrc
       git config --global user.email "travis@travis-ci.org"
       git config --global user.name "Travis CI"
+      git checkout ${TRAVIS_BRANCH}
       gem install bump
       bump patch --commit-message "[skip ci]"
     fi


### PR DESCRIPTION
In the build, we want to bump the version and commit it back to Git and push it to GitHub.

However, Travis by default checks out the build in a detached head state.  This means the build can not commit back to the branch.

This changes attaches the build back to the branch being built from.