### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,13 @@
 Changes for each release are listed in this file. Changes prior to v1.0.0 were not tracked.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
+
+## v1.0.0 (2023-12-11)
+
+[Full Changelog](https://github.com/main-branch/github_pages_rake_tasks/compare/v0.1.8..v1.0.0)
+
+Changes since v0.1.8:
+
+* 41317f7 Create initial CHANGELOG.md file (#24)
+* be21d78 Remove travis build definition (#23)
+* 9c7e76e Update project to new build and documentation standards  (#22)

--- a/lib/github_pages_rake_tasks/version.rb
+++ b/lib/github_pages_rake_tasks/version.rb
@@ -3,5 +3,5 @@
 
 module GithubPagesRakeTasks
   # Version of this module
-  VERSION = '0.1.8'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
# Release PR

## v1.0.0 (2023-12-11)

[Full Changelog](https://github.com/main-branch/github_pages_rake_tasks/compare/v0.1.8..v1.0.0)

Changes since v0.1.8:

* 41317f7 Create initial CHANGELOG.md file (#24)
* be21d78 Remove travis build definition (#23)
* 9c7e76e Update project to new build and documentation standards  (#22)
