### PR TITLE
Remove CodeClimate integration from CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['3.0', '3.2', head, jruby-head]
+        ruby: ['3.1', '3.4', jruby-head]
         operating-system: [ubuntu-latest]
         include:
-          - ruby: '3.0'
+          - ruby: '3.1'
             operating-system: windows-latest
           - ruby: jruby-head
             operating-system: windows-latest
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1
@@ -36,29 +36,3 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
-
-  coverage:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    name: Report test coverage to CodeClimate
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Initialize Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1
-          bundler-cache: true
-
-      - name: Run tests
-        run: bundle exec rake spec
-
-      - name: Report test coverage
-        uses: paambaati/codeclimate-action@v3.2.0
-        env:
-          CC_TEST_REPORTER_ID: 997ddf9df5b99897b448d7a7a13e332d57f0e29754d9b9d1414aaee611759422
-        with:
-          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   SuggestExtensions: false
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/github_pages_rake_tasks/)
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/github_pages_rake_tasks/file/CHANGELOG.md)
 [![Build Status](https://github.com/main-branch/github_pages_rake_tasks/workflows/CI%20Build/badge.svg?branch=main)](https://github.com/main-branch/github_pages_rake_tasks/actions?query=workflow%3ACI%20Build)
-[![Maintainability](https://api.codeclimate.com/v1/badges/a67ad0b61d3687e33181/maintainability)](https://codeclimate.com/github/main-branch/github_pages_rake_tasks/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/a67ad0b61d3687e33181/test_coverage)](https://codeclimate.com/github/main-branch/github_pages_rake_tasks/test_coverage)
 
 The `github_pages_rake_tasks` gem creates a rake task that pushes files
 from a local documentation directory to a remote Git repository branch.

--- a/github_pages_rake_tasks.gemspec
+++ b/github_pages_rake_tasks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = 'https://github.com/jcouball/github_pages_rake_tasks'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['rubygems_mfa_required'] = 'true'
@@ -42,10 +42,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'rake', '~> 13.1'
-  spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'rubocop', '~> 1.58'
-  spec.add_development_dependency 'semverify', '0.3.0'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'rubocop', '~> 1.75'
+  spec.add_development_dependency 'semverify', '~> 0.3'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
 


### PR DESCRIPTION
Eliminate CodeClimate reporting steps and badges from the CI configuration and documentation, streamlining the build process.