### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Check Commit Messages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@
 
       steps:
         - name: Checkout project
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Create release
-          uses: googleapis/release-please-action@v4
+          uses: googleapis/release-please-action@v5
           id: release
           with:
             token: ${{ secrets.AUTO_RELEASE_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions to the latest major versions:

- `actions/checkout`: `@v4` → `@v6` (latest: v6.0.2)
- `googleapis/release-please-action`: `@v4` → `@v5` (latest: v5.0.0)

Actions already on the latest major version (no change):
- `ruby/setup-ruby@v1` (latest: v1.305.0)
- `rubygems/release-gem@v1` (latest: v1.2.0)
- `wagoid/commitlint-github-action@v6` (latest: v6.2.1)